### PR TITLE
Drop support for Rails 7.1, Ruby 2.7 and Ruby 3.0

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -10,28 +10,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2", "3.3", "3.4"]
+        ruby: ["3.1", "3.2", "3.3", "3.4"]
         gemfile: [
-          dev/gemfiles/rails-7.1.x.gemfile,
           dev/gemfiles/rails-7.2.x.gemfile,
           dev/gemfiles/rails-8.0.x.gemfile,
           Gemfile
         ]
         exclude:
-          # Exclude rubies < 3.1 for ActiveModel ~> 7.2
-          - ruby: "2.7"
-            gemfile: dev/gemfiles/rails-7.2.x.gemfile
-          - ruby: "3.0"
-            gemfile: dev/gemfiles/rails-7.2.x.gemfile
-          # Exclude rubies < 3.2 for ActiveModel ~> 8.0
-          - ruby: "2.7"
-            gemfile: dev/gemfiles/rails-8.0.x.gemfile
-          - ruby: "2.7"
-            gemfile: Gemfile
-          - ruby: "3.0"
-            gemfile: dev/gemfiles/rails-8.0.x.gemfile
-          - ruby: "3.0"
-            gemfile: Gemfile
+          # Exclude rubies < 3.2 for ActiveModel < 8.0
           - ruby: "3.1"
             gemfile: dev/gemfiles/rails-8.0.x.gemfile
           - ruby: "3.1"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ plugins:
   - rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.1
   NewCops: enable
 
 Naming/FileName:

--- a/active_model_validations_reflection.gemspec
+++ b/active_model_validations_reflection.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
     f.match(excluded_dirs) || excluded_files.include?(f)
   end
 
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.7.0')
+  spec.required_ruby_version = '>= 3.1'
 
   spec.add_dependency  'activemodel',    '>= 3.2'
   spec.add_dependency  'activesupport',  '>= 3.2'

--- a/dev/gemfiles/rails-7.1.x.gemfile
+++ b/dev/gemfiles/rails-7.1.x.gemfile
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-source 'https://rubygems.org'
-
-gemspec path: '../..'
-gem 'activemodel', '~> 7.1.0'
-gem 'logger'
-gem 'mutex_m'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -102,4 +102,4 @@ RSpec.configure do |config|
   # Kernel.srand config.seed
 end
 
-Dir[File.join(__dir__, 'support', '**', '*.rb')].sort.each { |f| require f }
+Dir[File.join(__dir__, 'support', '**', '*.rb')].each { |f| require f }


### PR DESCRIPTION
1. Drop support for Rails 7.1 as it's now unmaintained
2. Bump minimum required Ruby version to 3.1 to match with Rails 7.2