### PR TITLE
Restore support for Ruby 3.1

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -12,12 +12,18 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ["3.2", "3.3", "3.4", "4.0"]
+        ruby: ["3.1", "3.2", "3.3", "3.4", "4.0"]
         gemfile: [
           dev/gemfiles/rails-7.2.x.gemfile,
           dev/gemfiles/rails-8.0.x.gemfile,
           Gemfile
         ]
+        exclude:
+          # Exclude rubies < 3.2 for ActiveModel < 8.0
+          - ruby: "3.1"
+            gemfile: dev/gemfiles/rails-8.0.x.gemfile
+          - ruby: "3.1"
+            gemfile: Gemfile
     env: # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps
       BUNDLE_GEMFILE: ${{ github.workspace }}/${{ matrix.gemfile }}
     steps:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ plugins:
   - rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 3.2
+  TargetRubyVersion: 3.1
   NewCops: enable
 
 Naming/FileName:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
-* Remove Ruby 3.1 from the test matrix (#21)
 * Add Ruby 4.0 to the test matrix (#20)
 
 ## Version 0.2.0 (2025-10-23)

--- a/active_model_validations_reflection.gemspec
+++ b/active_model_validations_reflection.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
     f.match(excluded_dirs) || excluded_files.include?(f)
   end
 
-  spec.required_ruby_version = '>= 3.2'
+  spec.required_ruby_version = '>= 3.1'
 
   spec.add_dependency  'activemodel',    '>= 3.2'
   spec.add_dependency  'activesupport',  '>= 3.2'


### PR DESCRIPTION
To stay synced with Rails-related dependencies minimum supported version.

This reverts commit ce36f923bef8fc6d71518771973d9fcf4c3f1f3d.